### PR TITLE
fix: 사이트 보기 텍스트 UI 개선 (https:// 글자 제거)

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -557,7 +557,7 @@ export default function Page() {
           <div className="space-y-4">
             <div className="bg-gray-100 rounded-lg p-4">
               <p className="text-body-r text-gray-800 break-all">
-                https://chefriend.kr/{currentStore?.siteLink}
+                chefriend.kr/{currentStore?.siteLink}
               </p>
             </div>
             <DialogFooter className="flex gap-2 sm:justify-center">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the site URL dialog to display the domain without the "https://" prefix, changing from "https://chefriend.kr/{...}" to "chefriend.kr/{...}". This refines visual presentation and aligns with common display conventions. Copy-to-clipboard and open-in-browser actions remain unchanged, so users can continue as before. No behavioral differences expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->