### PR TITLE
fix: 미리보기에서 링크 클릭시 이동 안 되게 변경

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -787,7 +787,7 @@ export default function HomePage() {
             <DialogTitle>손님이 보는 화면</DialogTitle>
           </DialogHeader>
           <div className="overflow-auto max-h-[70vh]">
-            <CustomerView storeData={previewStoreData} />
+            <CustomerView storeData={previewStoreData} isPreview={true} />
           </div>
         </DialogContent>
       </Dialog>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -312,10 +312,12 @@ function SortableLinkItem({
 export default function HomePage() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [isSiteLinkDialogOpen, setIsSiteLinkDialogOpen] = useState(false);
+  // const [isSiteLinkDialogOpen, setIsSiteLinkDialogOpen] = useState(false); // 드롭다운으로 변경
+  const [showSiteLinkDropdown, setShowSiteLinkDropdown] = useState(false);
   const [isProfileImageDialogOpen, setIsProfileImageDialogOpen] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const siteLinkDropdownRef = useRef<HTMLDivElement>(null);
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
   const [isPreviewDialogOpen, setIsPreviewDialogOpen] = useState(false);
   const [links, setLinks] = useState<LinkItem[]>([]);
@@ -362,6 +364,30 @@ export default function HomePage() {
       setLinks(convertedLinks);
     }
   }, [currentStore]);
+
+  // 외부 클릭 감지로 사이트링크 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (
+        siteLinkDropdownRef.current &&
+        !siteLinkDropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowSiteLinkDropdown(false);
+      }
+    };
+
+    if (showSiteLinkDropdown) {
+      setTimeout(() => {
+        document.addEventListener("click", handleClickOutside);
+        document.addEventListener("touchend", handleClickOutside);
+      }, 0);
+    }
+
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener("touchend", handleClickOutside);
+    };
+  }, [showSiteLinkDropdown]);
 
   // Drag and drop sensors (모바일 터치 지원)
   const sensors = useSensors(
@@ -660,14 +686,38 @@ export default function HomePage() {
               <p className="text-caption-r text-gray-800">
                 {currentStore?.description && currentStore.description.length > 0 ? currentStore.description : "안녕하세요 사장님 👨‍🌾"}
               </p>
-              {/* 사이트 주소 - 클릭하여 Dialog 오픈 */}
+              {/* 사이트 주소 - 드롭다운 메뉴로 변경 */}
               {currentStore?.siteLink && (
-                <button
-                  onClick={() => setIsSiteLinkDialogOpen(true)}
-                  className="text-body-r text-purple-700 flex items-center gap-1 hover:underline text-left"
-                >
-                  chefriend.kr/{currentStore.siteLink}🔗
-                </button>
+                <div ref={siteLinkDropdownRef} className="relative">
+                  <button
+                    onClick={() => setShowSiteLinkDropdown(!showSiteLinkDropdown)}
+                    className="text-body-r text-purple-700 flex items-center gap-1 hover:underline text-left"
+                  >
+                    chefriend.kr/{currentStore.siteLink}🔗
+                  </button>
+                  {showSiteLinkDropdown && (
+                    <div className="absolute top-full mt-2 w-48 bg-white border-2 border-gray-200 rounded-2xl shadow-lg overflow-hidden z-10">
+                      <button
+                        onClick={() => {
+                          handleCopySiteLink();
+                          setShowSiteLinkDropdown(false);
+                        }}
+                        className="w-full px-4 py-3 text-body-sb text-gray-600 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+                      >
+                        주소 복사하기
+                      </button>
+                      <button
+                        onClick={() => {
+                          handleViewSite();
+                          setShowSiteLinkDropdown(false);
+                        }}
+                        className="w-full px-4 py-3 text-body-sb text-gray-600 hover:bg-gray-50 transition-colors flex items-center justify-center gap-2 border-t border-gray-200"
+                      >
+                        사이트 보기
+                      </button>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
           </div>
@@ -792,8 +842,8 @@ export default function HomePage() {
         </DialogContent>
       </Dialog>
 
-      {/* 사이트 주소 Dialog */}
-      <Dialog
+      {/* 사이트 주소 Dialog - 드롭다운으로 변경됨 */}
+      {/* <Dialog
         open={isSiteLinkDialogOpen}
         onOpenChange={setIsSiteLinkDialogOpen}
       >
@@ -825,7 +875,7 @@ export default function HomePage() {
             </DialogFooter>
           </div>
         </DialogContent>
-      </Dialog>
+      </Dialog> */}
 
       {/* 프로필 이미지 미리보기 Dialog */}
       <Dialog

--- a/src/components/customer-view.tsx
+++ b/src/components/customer-view.tsx
@@ -8,9 +8,10 @@ import { ChevronDown } from "lucide-react";
 
 interface CustomerViewProps {
   storeData: StoreResponse;
+  isPreview?: boolean;
 }
 
-export function CustomerView({ storeData }: CustomerViewProps) {
+export function CustomerView({ storeData, isPreview = false }: CustomerViewProps) {
   const links = storeData.links || [];
 
   return (
@@ -61,6 +62,7 @@ export function CustomerView({ storeData }: CustomerViewProps) {
                   linkType={link.linkType}
                   url={link.url}
                   label={link.label || link.customLabel}
+                  onClick={isPreview ? () => {} : undefined}
                 />
               ))
           ) : (


### PR DESCRIPTION
# 드롭다운 외부 클릭 기능 테스트 체크리스트

## 1. 기본 동작 테스트

### 1.1 드롭다운 열기
- [x] 사이트 주소 링크(`chefriend.kr/{siteLink}🔗`) 클릭 시 드롭다운 표시
- [x] "주소 복사하기", "사이트 보기" 두 메뉴 표시
- [x] 회색 테두리, 둥근 모서리, 그림자 스타일 확인

### 1.2 드롭다운 토글
- [x] 사이트 주소 링크 재클릭 시 드롭다운 닫힘
- [x] 닫힌 상태에서 재클릭 시 다시 열림

## 2. 외부 클릭 감지 테스트 ⭐ 핵심

### 2.1 데스크톱 (마우스)
- [x] 화면 빈 공간 클릭 → 드롭다운 닫힘
- [x] 프로필 사진 클릭 → 드롭다운 닫힘
- [x] 다른 링크 버튼 클릭 → 드롭다운 닫힘
- [x] 저장 버튼 클릭 → 드롭다운 닫힘

### 2.2 모바일 (터치)
- [x] 화면 빈 공간 터치 → 드롭다운 닫힘
- [x] 다른 UI 요소 터치 → 드롭다운 닫힘

### 2.3 내부 클릭 (닫히면 안 됨)
- [x] "주소 복사하기" 버튼에 마우스 올려도 유지
- [x] "사이트 보기" 버튼에 마우스 올려도 유지
- [x] 드롭다운 테두리/배경 클릭해도 유지

## 3. 메뉴 기능 테스트

### 3.1 주소 복사하기
- [x] 클립보드에 URL 복사
- [x] "사이트 주소가 복사되었습니다!" 토스트 표시
- [x] 복사된 URL: `https://chefriend.kr/{siteLink}` 형식
- [x] 클릭 후 드롭다운 자동 닫힘

### 3.2 사이트 보기
- [x] 새 탭 열림
- [x] `https://chefriend.kr/{siteLink}` 주소로 이동
- [x] 클릭 후 드롭다운 자동 닫힘

## 4. 경계 케이스

### 4.1 빠른 클릭
- [x] 사이트 주소 링크 빠르게 연속 클릭해도 정상 동작
- [x] 열리는 즉시 외부 클릭해도 정상 닫힘

### 4.2 다른 다이얼로그와의 상호작용
- [x] "링크 추가" 버튼 클릭 → 드롭다운 닫힘
- [x] "미리보기" 버튼 클릭 → 드롭다운 닫힘

## 5. 반응형 테스트

- [x] 모바일 화면 (320px~480px)
- [x] 태블릿 화면 (768px~1024px)
- [ ] 데스크톱 화면 (1920px+)

## 6. 브라우저 호환성

- [x] Chrome
- [ ] Safari (iOS 포함)
- [ ] Firefox
- [ ] Edge
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site link now opens a compact dropdown with "주소 복사하기" and "사이트 보기" actions, and closes when tapping outside.

* **Improvements**
  * Preview display now disables navigation and button interactions to prevent accidental actions.
  * Minor UI structure updates to streamline the site-link and preview experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->